### PR TITLE
fix: correct default remote name

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -27,11 +27,11 @@
     ================================================================
     DEFAULTS: Default settings for all projects.
     ================================================================
-    All projects will use the 'cozmicos' remote and the 'main' branch
+    All projects will use the 'cozmicos' remote and the 'a15' branch
     by default, unless specified otherwise in the project tag.
     ================================================================
   -->
-  <default remote="CozmicOS"
+  <default remote="cozmicos"
            revision="a15"
            sync-j="4" />
 


### PR DESCRIPTION
## Summary
- fix default remote name case to match remote definition
- update comment to reference correct branch

## Testing
- `xmllint --noout default.xml snippets/*.xml`


------
https://chatgpt.com/codex/tasks/task_e_689da6ec5b8c8332b2cce5b6bcf68b5e