### PR TITLE
Fix manifest remotes to use cozmicos

### DIFF
--- a/snippets/Spacewar.xml
+++ b/snippets/Spacewar.xml
@@ -9,15 +9,15 @@
     ================================================================
   --> 
   <!-- Device Tree -->
-  <project path="device/nothing/Spacewar" remote="github" name="android_device_nothing_Spacewar" />
+  <project path="device/nothing/Spacewar" remote="cozmicos" name="android_device_nothing_Spacewar" />
 
   <!-- Kernel Files -->
-  <project path="kernel/nothing/sm7325" remote="github" name="android_kernel_nothing_sm7325" />
+  <project path="kernel/nothing/sm7325" remote="cozmicos" name="android_kernel_nothing_sm7325" />
   
   <!-- Hardware Files -->
-  <project path="hardware/nothing" remote="github" name="android_hardware_nothing" />
+  <project path="hardware/nothing" remote="cozmicos" name="android_hardware_nothing" />
 
   <!-- Vendor blobs  -->
-  <project path="vendor/nothing/Spacewar" remote="github" name="proprietary_vendor_nothing_Spacewar" />
+  <project path="vendor/nothing/Spacewar" remote="cozmicos" name="proprietary_vendor_nothing_Spacewar" />
 
 </manifest>

--- a/snippets/cozmic.xml
+++ b/snippets/cozmic.xml
@@ -2,9 +2,9 @@
 <manifest>
 
   <!-- CozmicOS additions -->
-  <project path="packages/apps/Settings" remote="github" name="platform_packages_apps_Settings" />
-  <project path="packages/apps/ThemePicker" remote="github" name="platform_packages_apps_ThemePicker" />
-  <project path="frameworks/base" remote="github" name="platform_frameworks_base" />
-  <project path="system/sepolicy" remote="github" name="platform_system_sepolicy" />
+  <project path="packages/apps/Settings" remote="cozmicos" name="platform_packages_apps_Settings" />
+  <project path="packages/apps/ThemePicker" remote="cozmicos" name="platform_packages_apps_ThemePicker" />
+  <project path="frameworks/base" remote="cozmicos" name="platform_frameworks_base" />
+  <project path="system/sepolicy" remote="cozmicos" name="platform_system_sepolicy" />
 
 </manifest>


### PR DESCRIPTION
## Summary
- replace github remotes with cozmicos in Spacewar and CozmicOS snippet manifests

## Testing
- `repo init -u file:///workspace/platform_manifest -m default.xml` *(fails: Cannot get https://gerrit.googlesource.com/git-repo/clone.bundle: 403)*
- `repo sync` *(fails: command 'sync' requires repo to be installed first)*

------
https://chatgpt.com/codex/tasks/task_e_689dade1acb883328386774fc21042c9