### PR TITLE
Fix manifest include order for Settings replacement

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -56,7 +56,7 @@
   -->
   <include name="snippets/core.xml" />
   <include name="snippets/lineage.xml" />
-   <include name="snippets/cozmic.xml" />
   <include name="snippets/removals.xml" />
+  <include name="snippets/cozmic.xml" />
 
 </manifest>


### PR DESCRIPTION
## Summary
- avoid duplicate path errors by loading removals before custom projects in the default manifest

## Testing
- `xmllint --noout default.xml snippets/core.xml snippets/cozmic.xml snippets/lineage.xml snippets/removals.xml`


------
https://chatgpt.com/codex/tasks/task_e_689db249cdcc83329d91126a25fc8ebb